### PR TITLE
Use default configuration file if none is given

### DIFF
--- a/config/.jshintrc
+++ b/config/.jshintrc
@@ -1,0 +1,33 @@
+{
+  "asi": false,
+  "bitwise": true,
+  "browser": true,
+  "camelcase": true,
+  "curly": true,
+  "forin": true,
+  "immed": true,
+  "latedef": "nofunc",
+  "maxlen": 80,
+  "newcap": true,
+  "noarg": true,
+  "noempty": true,
+  "nonew": true,
+  "predef": [
+    "$",
+    "jQuery",
+
+    "jasmine",
+    "beforeEach",
+    "describe",
+    "expect",
+    "it",
+
+    "angular",
+    "inject",
+    "module"
+  ],
+  "quotmark": true,
+  "trailing": true,
+  "undef": true,
+  "unused": true
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,28 @@
+var fs = require("fs");
+
+var UNCONFIGURED_CONFIG = "{}";
+
 function Config(rawConfig) {
-  this.rawConfig = rawConfig;
-}
+  if (_isInvalidConfig(rawConfig)) {
+    this.rawConfig = _defaultConfig();
+  } else {
+    this.rawConfig = rawConfig;
+  }
+};
+
+function _isInvalidConfig(rawConfig) {
+  if (!rawConfig || rawConfig == UNCONFIGURED_CONFIG) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
+function _defaultConfig() {
+  var defaultConfigFile = "config/.jshintrc";
+
+  return fs.readFileSync(defaultConfigFile, "utf8", function() {});
+};
 
 Config.prototype.parse = function() {
   var config = this.rawConfig || "{}";

--- a/tests/config-test.js
+++ b/tests/config-test.js
@@ -1,3 +1,4 @@
+var fs = require("fs");
 var Config = require("../lib/config");
 
 QUnit.module("Config");
@@ -11,12 +12,25 @@ test("Parsing a JSHint config file", function() {
   );
 });
 
-test("Having no JSHint config file", function() {
-  var config = new Config(null);
+test("Given an empty JSHint config file", function() {
+  var config = new Config("{}");
 
+  var expectedConfig = JSON.parse(fs.readFileSync("config/.jshintrc", "utf8"));
+  var parsedConfig = config.parse();
   deepEqual(
-    config.parse(),
-    {}
+    parsedConfig,
+    expectedConfig
+  );
+});
+
+test("Having no JSHint config file", function() {
+  var config = new Config(undefined);
+
+  var expectedConfig = JSON.parse(fs.readFileSync("config/.jshintrc", "utf8"));
+  var parsedConfig = config.parse();
+  deepEqual(
+    parsedConfig,
+    expectedConfig
   );
 });
 


### PR DESCRIPTION
To have a migration path for existing users, we're keeping the same
behavior as the current `javascript` linter in Hound. Which as a default
configuration file.

https://trello.com/c/LzngtlIn